### PR TITLE
Improve input validation and timing configuration

### DIFF
--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,0 +1,14 @@
+from tetris_phone_bot import TemporalFilter
+
+
+def test_find_position_consensus_ignores_invalid():
+    tf = TemporalFilter()
+    valid_piece = [(0, 0), (0, 1)]
+    pieces = [valid_piece, []]
+    assert tf._find_position_consensus(pieces) == valid_piece
+
+
+def test_find_position_consensus_all_invalid_returns_none():
+    tf = TemporalFilter()
+    pieces = [[], []]
+    assert tf._find_position_consensus(pieces) is None

--- a/tests/test_delays.py
+++ b/tests/test_delays.py
@@ -1,0 +1,10 @@
+import json
+from tetris_phone_bot import TetrisConfig
+
+
+def test_delay_overrides(tmp_path):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"delays": {"short": 0.1}}))
+    cfg = TetrisConfig(str(cfg_file))
+    assert cfg.get_delay("short") == 0.1
+    assert cfg.get_delay("long") == 0.8

--- a/tests/test_parse_rect.py
+++ b/tests/test_parse_rect.py
@@ -1,0 +1,17 @@
+import argparse
+import pytest
+from tetris_phone_bot import parse_rect
+
+
+def test_parse_rect_valid():
+    assert parse_rect("0.1,0.2,0.3,0.4") == (0.1, 0.2, 0.3, 0.4)
+
+
+def test_parse_rect_invalid_format():
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_rect("a,b,c,d")
+
+
+def test_parse_rect_out_of_range():
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_rect("1.2,0,0.5,0.5")


### PR DESCRIPTION
## Summary
- Validate board rectangle parameters explicitly and handle optional imports with logging
- Replace magic numbers with BOARD_ROWS/COLS constants and configurable delays
- Add tests for rectangle parsing, consensus handling, and delay overrides

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acf23ff75c83258ea95b486d19c492