### PR TITLE
Refactor vision board analysis into helpers

### DIFF
--- a/tests/test_vision_helpers.py
+++ b/tests/test_vision_helpers.py
@@ -1,0 +1,92 @@
+import numpy as np
+from vision import TetrisVision, TetrisConfig
+
+def create_vision():
+    config = TetrisConfig()
+    return TetrisVision(config)
+
+
+def test_detect_components_returns_expected_values(monkeypatch):
+    vision = create_vision()
+    rows, cols = 20, 10
+    crop = np.zeros((rows, cols, 3), dtype=np.uint8)
+    debug_mask = np.zeros((rows, cols), dtype=np.uint8)
+    active_grid = np.zeros((rows, cols), dtype=bool)
+    active_grid[0, 0] = True
+
+    def fake_detect(*args, **kwargs):
+        return [(0, 0)], [(1, 1)], {"debug_mask": None}
+
+    def fake_occ(*args, **kwargs):
+        return np.zeros((rows, cols), dtype=bool), np.zeros((rows, cols), dtype=bool)
+
+    def fake_occ_ml(*args, **kwargs):
+        return (
+            np.zeros((rows, cols), dtype=bool),
+            active_grid,
+            np.zeros((rows, cols), dtype=bool),
+            debug_mask,
+        )
+
+    monkeypatch.setattr("vision.detect_pieces_multilayer", fake_detect)
+    monkeypatch.setattr("vision.occupancy_grid", fake_occ)
+    monkeypatch.setattr("vision.occupancy_grid_multilayer", fake_occ_ml)
+
+    occ, raw_piece, raw_ghost, info = vision._detect_components(crop, rows, cols)
+
+    assert raw_piece == [(0, 0)]
+    assert raw_ghost == [(1, 1)]
+    assert np.array_equal(occ, active_grid)
+    assert info["debug_mask"] is debug_mask
+
+
+def test_apply_temporal_filter_recomputes_ghost(monkeypatch):
+    vision = create_vision()
+
+    class DummyFilter:
+        def __init__(self):
+            self.added = None
+
+        def add_detection(self, cells):
+            self.added = cells
+
+        def get_filtered_piece(self):
+            return [(0, 1)]
+
+        def get_stability_score(self):
+            return 0.5
+
+    vision.temporal_filter = DummyFilter()
+
+    def fake_detect(*args, **kwargs):
+        return None, [(9, 9)], {}
+
+    monkeypatch.setattr("vision.detect_pieces_multilayer", fake_detect)
+
+    piece, ghost = vision._apply_temporal_filter(
+        [(1, 1)], [(2, 2)], np.zeros((20, 10, 3)), 20, 10, True
+    )
+
+    assert piece == [(0, 1)]
+    assert ghost == [(9, 9)]
+    assert vision.temporal_filter.added == [(1, 1)]
+
+
+def test_log_analysis_updates_stats(monkeypatch):
+    vision = create_vision()
+    occ = np.zeros((20, 10), dtype=bool)
+    piece = [(0, 0)]
+    ghost = []
+
+    def fake_extract(occ_grid, ghost_grid):
+        return [[(0, 0)], [(1, 1)]], []
+
+    monkeypatch.setattr("vision.extract_components_by_type", fake_extract)
+
+    rate, components = vision._log_analysis(
+        occ, piece, ghost, 20, 10, False, piece
+    )
+
+    assert occ[0, 0]
+    assert rate == 1 / (20 * 10)
+    assert components == 2

--- a/vision.py
+++ b/vision.py
@@ -1,0 +1,192 @@
+import logging
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from tetris_phone_bot import (
+    BOARD_ROWS,
+    BOARD_COLS,
+    BoardAnalysis,
+    TemporalFilter,
+    TetrisConfig,
+    detect_pieces_multilayer,
+    occupancy_grid,
+    occupancy_grid_multilayer,
+    extract_components_by_type,
+)
+
+
+class TetrisVision:
+    """Maneja todo el análisis visual del tablero de Tetris"""
+
+    def __init__(self, config: TetrisConfig):
+        self.config = config
+        self.temporal_filter = TemporalFilter(
+            history_size=config.config.get("vision", {}).get("temporal_filter_history", 7),
+            confidence_threshold=config.config.get("vision", {}).get("temporal_filter_threshold", 0.7),
+        )
+
+    def _detect_components(self, crop: np.ndarray, rows: int, cols: int):
+        """Detección primaria de piezas y grillas de ocupación"""
+        raw_piece_cells, raw_ghost_cells, debug_info = detect_pieces_multilayer(crop, rows, cols)
+        occupancy_grid(crop, rows, cols, mode="normal")
+        _, active_grid, _, debug_mask = occupancy_grid_multilayer(crop, rows, cols)
+        occ = active_grid.copy()
+        debug_info["debug_mask"] = debug_mask
+        return occ, raw_piece_cells, raw_ghost_cells, debug_info
+
+    def _apply_temporal_filter(
+        self,
+        raw_piece_cells,
+        raw_ghost_cells,
+        crop: np.ndarray,
+        rows: int,
+        cols: int,
+        use_temporal_filter: bool = True,
+    ):
+        """Aplica filtrado temporal para estabilizar la pieza detectada"""
+        piece_cells = raw_piece_cells
+        ghost_cells = raw_ghost_cells
+
+        if use_temporal_filter and raw_piece_cells:
+            self.temporal_filter.add_detection(raw_piece_cells)
+            piece_cells = self.temporal_filter.get_filtered_piece()
+            if piece_cells != raw_piece_cells and piece_cells:
+                _, ghost_cells, _ = detect_pieces_multilayer(crop, rows, cols)
+
+        return piece_cells, ghost_cells
+
+    def _log_analysis(
+        self,
+        occ: np.ndarray,
+        piece_cells,
+        ghost_cells,
+        rows: int,
+        cols: int,
+        use_temporal_filter: bool,
+        raw_piece_cells,
+    ):
+        """Calcula estadísticas y registra mensajes de diagnóstico"""
+        if piece_cells:
+            for r, c in piece_cells:
+                if 0 <= r < rows and 0 <= c < cols:
+                    occ[r, c] = False
+            for r, c in piece_cells:
+                if 0 <= r < rows and 0 <= c < cols:
+                    occ[r, c] = True
+
+        num_occupied = int(occ.sum())
+        total_cells = rows * cols
+        occupation_rate = num_occupied / total_cells
+
+        components = extract_components_by_type(occ, np.zeros_like(occ))[0]
+        components_found = len(components)
+
+        method_info = "multilayer + temporal" if use_temporal_filter else "multilayer"
+        stability_score = self.temporal_filter.get_stability_score() if use_temporal_filter else 1.0
+
+        logging.debug(f"👁️ VISION ANALYSIS ({method_info}):")
+        logging.debug(
+            f"   🔍 Grid analysis: {num_occupied}/{total_cells} occupied ({occupation_rate:.1%})"
+        )
+        logging.debug(f"   🧩 Components found: {components_found}")
+        logging.debug(
+            f"   🎯 Active piece: {len(piece_cells) if piece_cells else 0} cells detected"
+        )
+        logging.debug(
+            f"   👻 Ghost piece: {len(ghost_cells) if ghost_cells else 0} cells detected"
+        )
+        if use_temporal_filter:
+            logging.debug(f"   🎚️ Temporal stability: {stability_score:.2f}")
+            if raw_piece_cells != piece_cells:
+                logging.debug(
+                    f"   🔄 Temporal filter active: raw {len(raw_piece_cells) if raw_piece_cells else 0} -> filtered {len(piece_cells) if piece_cells else 0}"
+                )
+
+        if piece_cells:
+            try:
+                r_min = min(r for r, _ in piece_cells)
+                r_max = max(r for r, _ in piece_cells)
+                c_min = min(c for _, c in piece_cells)
+                c_max = max(c for _, c in piece_cells)
+                piece_height = r_max - r_min + 1
+                piece_width = c_max - c_min + 1
+                logging.info(
+                    f"🎯 Piece detected ({method_info}): {len(piece_cells)} cells at rows {r_min}-{r_max}, cols {c_min}-{c_max} ({piece_width}x{piece_height})"
+                )
+            except ValueError:
+                logging.info(
+                    f"🎯 Piece detected ({method_info}): {len(piece_cells)} cells (position unknown)"
+                )
+
+        if ghost_cells:
+            try:
+                r_min = min(r for r, _ in ghost_cells)
+                r_max = max(r for r, _ in ghost_cells)
+                c_min = min(c for _, c in ghost_cells)
+                c_max = max(c for _, c in ghost_cells)
+                logging.info(
+                    f"👻 Ghost detected ({method_info}): {len(ghost_cells)} cells at rows {r_min}-{r_max}, cols {c_min}-{c_max}"
+                )
+            except ValueError:
+                logging.info(
+                    f"👻 Ghost detected ({method_info}): {len(ghost_cells)} cells"
+                )
+
+        if piece_cells and len(piece_cells) > 4:
+            logging.error(
+                f"❌ CRITICAL: Oversized piece detected: {len(piece_cells)} cells (max allowed: 4)"
+            )
+            logging.error(f"   Piece cells: {piece_cells}")
+            logging.error(
+                "   This indicates vision system malfunction - piece will be rejected"
+            )
+        elif piece_cells and len(piece_cells) == 1:
+            logging.warning(
+                "⚠️ Single cell piece detected - possibly noise or I-piece end"
+            )
+        elif piece_cells and len(piece_cells) in [2, 3, 4]:
+            logging.debug(f"✅ Valid piece size: {len(piece_cells)} cells")
+
+        if occupation_rate > 0.8:
+            logging.warning(
+                f"⚠️ Very high board occupation: {occupation_rate:.1%} - may indicate detection issues"
+            )
+        if components_found > 15:
+            logging.warning(
+                f"⚠️ High component count: {components_found} - possible noise in detection"
+            )
+
+        if piece_cells and ghost_cells:
+            if len(set(piece_cells) & set(ghost_cells)) > 0:
+                logging.warning(
+                    "⚠️ Piece and ghost overlap detected - may indicate detection confusion"
+                )
+
+        return occupation_rate, components_found
+
+    def analyze_board(
+        self,
+        crop: np.ndarray,
+        rows: int = BOARD_ROWS,
+        cols: int = BOARD_COLS,
+        use_temporal_filter: bool = True,
+    ) -> BoardAnalysis:
+        """Orquesta el análisis de tablero usando funciones auxiliares"""
+        occ, raw_piece_cells, raw_ghost_cells, debug_info = self._detect_components(
+            crop, rows, cols
+        )
+        piece_cells, ghost_cells = self._apply_temporal_filter(
+            raw_piece_cells, raw_ghost_cells, crop, rows, cols, use_temporal_filter
+        )
+        occupation_rate, components_found = self._log_analysis(
+            occ, piece_cells, ghost_cells, rows, cols, use_temporal_filter, raw_piece_cells
+        )
+        return BoardAnalysis(
+            occupancy_grid=occ,
+            debug_mask=debug_info["debug_mask"],
+            active_piece=piece_cells,
+            ghost_piece=ghost_cells,
+            occupation_rate=occupation_rate,
+            components_found=components_found,
+        )


### PR DESCRIPTION
## Summary
- Extracted detection, temporal filtering, and logging from `analyze_board` into dedicated helpers
- Simplified `TetrisVision.analyze_board` to orchestrate the new `_detect_components`, `_apply_temporal_filter`, and `_log_analysis` helpers
- Added unit tests for each helper function

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acf869af20832592f8add21739a107